### PR TITLE
Updating install-kali.sh for Kali 2.0 to handle missing libnl dependency

### DIFF
--- a/kali-install.sh
+++ b/kali-install.sh
@@ -7,11 +7,21 @@ echo [+] If you are worried about that, hit Ctl-C now, or hit Enter to continue
 read
 
 # Install build dependencies
-apt-get install libnl-dev libssl-dev
+# Checking for Kali 2, since libnl1 is not prebuild any longer
+if grep "Kali GNU/Linux 2" /etc/lsb-release &>/dev/null; then
+	# Running Kali Linux 2.x
+	# Changing the config file to use libnl 3.2
+	sed -i 's/#CONFIG_LIBNL32=y/CONFIG_LIBNL32=y/' hostapd-mana/hostapd/.config
+	apt-get --yes install libnl-genl-3-dev libssl-dev
+else
+	apt-get --yes install libnl-dev libssl-dev
+fi
+
+
 make
 
 # Install dependencies
-apt-get install apache2 dsniff isc-dhcp-server macchanger \
+apt-get --yes install apache2 dsniff isc-dhcp-server macchanger \
     metasploit-framework python-dnspython python-pcapy python-scapy \
     sslsplit stunnel4 tinyproxy procps iptables asleap scapy
 make install


### PR DESCRIPTION
I altered the kali-install.sh file in order to support Kali 2.0

Kali 2.0 doesn't support importing libnl1 any longer, hence resulting in make for hostapd to fail to compile. The patch checks whether Kali 2.x is run, and if so, updates the .config file for hostapd to support libnl-3.2, and instruct apt-get to fetch the newer libnl.

Also, I added the option --yes to apt-get in order to bypass questions when two or more packages need installing.