### PR TITLE
Fixing Client not to connecting to the fake AP

### DIFF
--- a/run-mana/conf/karmetasploit.rc
+++ b/run-mana/conf/karmetasploit.rc
@@ -1,10 +1,11 @@
 #DNS
 
-#use auxiliary/server/fakedns
-#set TARGETACTION FAKE
-#set TARGETHOST 10.0.0.1
-#set TARGETDOMAIN *
-#exploit -j
+use auxiliary/server/fakedns
+set TARGETACTION FAKE
+set TARGETHOST 10.0.0.1
+set TARGETDOMAIN *
+exploit -j
+exploit -j
 
 #Unencrypted services
 

--- a/run-mana/start-noupstream.sh
+++ b/run-mana/start-noupstream.sh
@@ -22,8 +22,9 @@ sleep 5
 ifconfig $phy 10.0.0.1 netmask 255.255.255.0
 route add -net 10.0.0.0 netmask 255.255.255.0 gw 10.0.0.1
 
-dnsmasq -C /etc/mana-toolkit/dnsmasq-dhcpd.conf $phy
-dnsspoof -i $phy -f /etc/mana-toolkit/dnsspoof.conf&
+#dnsmasq -C /etc/mana-toolkit/dnsmasq-dhcpd.conf $phy
+dnsmasq -C /etc/mana-toolkit/dnsmasq-dhcpd.conf -i $phy
+#dnsspoof -i $phy -f /etc/mana-toolkit/dnsspoof.conf&
 service apache2 start
 stunnel4 /etc/mana-toolkit/stunnel.conf
 tinyproxy -c /etc/mana-toolkit/tinyproxy.conf&


### PR DESCRIPTION
Title: start-noupstream.sh - Client not to connecting to the fake AP
URL: https://github.com/sensepost/mana/issues/66

I sorted it out using other DNS server. Basically what I did was the next.
Add to the /etc/mana-toolkit/karmetasploit.rc file the next lines:

use auxiliary/server/fakedns
set TARGETACTION FAKE
set TARGETHOST 10.0.0.1
set TARGETDOMAIN *
exploit -j
exploit -j
Comment the next lines in the start-noupstream.sh script:
dnsspoof -i $phy -f /etc/mana-toolkit/dnsspoof.conf& dnsmasq -C /etc/mana-toolkit/dnsmasq-dhcpd.conf $phy

And add the next one:
dnsmasq -C /etc/mana-toolkit/dnsmasq-dhcpd.conf -i $phy