### PR TITLE
Update start-nat-full.sh

### DIFF
--- a/run-mana/start-nat-full.sh
+++ b/run-mana/start-nat-full.sh
@@ -22,7 +22,7 @@ sleep 5
 ifconfig $phy 10.0.0.1 netmask 255.255.255.0
 route add -net 10.0.0.0 netmask 255.255.255.0 gw 10.0.0.1
 
-dnsmasq -z -C /etc/mana-toolkit/dnsmasq-dhcpd.conf -i $phy -I lo
+dnsmasq -z -C /etc/mana-toolkit/dnsmasq-dhcpd.conf -i $phy -I lo -p 0
 
 echo '1' > /proc/sys/net/ipv4/ip_forward
 iptables --policy INPUT ACCEPT


### PR DESCRIPTION
Fixed double allocation of port 53 to DNS and DHCP servers.